### PR TITLE
Replaced `char`s with `int8_t`s and `unsigned char`s with `uint8_t` for clarity

### DIFF
--- a/main.c
+++ b/main.c
@@ -328,8 +328,7 @@ void compute_crc_table(unsigned int* crc_table) {
 }
 
 
-unsigned int update_crc(unsigned int* crc_table, unsigned crc,
-                           unsigned char *buf, int len) {
+unsigned int update_crc(unsigned int* crc_table, unsigned crc, uint8_t *buf, int len) {
 
   char b;
   unsigned c = crc ^ 0xffffffff;
@@ -550,7 +549,7 @@ uint16_t parse_waveform(char* data, uint32_t* wav_addrs, uint32_t wav_addr, FILE
   return state_count;
 }
 
-int parse_temp_ranges(struct waveform_data_header* header, char* data, char* tr_start, uint8_t tr_count, uint32_t* wav_addrs, int first_pass, FILE* outfile, int do_print) {
+int parse_temp_ranges(struct waveform_data_header* header, int8_t* data, int8_t* tr_start, uint8_t tr_count, uint32_t* wav_addrs, int first_pass, FILE* outfile, int do_print) {
   struct pointer* tr;
   uint8_t checksum;
   uint8_t i;
@@ -675,7 +674,7 @@ int parse_temp_ranges(struct waveform_data_header* header, char* data, char* tr_
 }
 
 
-int parse_modes(struct waveform_data_header* header, char* data, char* mode_start, uint8_t mode_count, uint8_t temp_range_count, uint32_t* wav_addrs, int first_pass, FILE* outfile, int do_print) {
+int parse_modes(struct waveform_data_header* header, int8_t* data, int8_t* mode_start, uint8_t mode_count, uint8_t temp_range_count, uint32_t* wav_addrs, int first_pass, FILE* outfile, int do_print) {
   struct pointer* mode;
   uint8_t checksum;
   uint8_t i;
@@ -786,7 +785,7 @@ int check_xwia(char* xwia, int do_print) {
   return 0;
 }
 
-int parse_temp_range_table(char* table, uint8_t range_count, FILE* outfile, int do_print) {
+int parse_temp_range_table(int8_t* table, uint8_t range_count, FILE* outfile, int do_print) {
   uint8_t i;
   uint8_t checksum;
   struct temp_range range;
@@ -904,14 +903,14 @@ void usage(FILE* fd) {
 
 int main(int argc, char **argv) {
 
-  char* data;
+  int8_t* data;
   char* infile_path;
   FILE* infile = NULL;
   size_t len;
   struct waveform_data_header* header; // points to `data` at beginning of header
   struct stat st;
-  char* modes; // points to `data` where the modes table begins
-  char* temp_range_table; // points to `data` where the temp range table begins
+  int8_t* modes; // points to `data` where the modes table begins
+  int8_t* temp_range_table; // points to `data` where the temp range table begins
   uint32_t xwia_len;
   uint8_t mode_count;
   uint8_t temp_range_count;

--- a/main.c
+++ b/main.c
@@ -328,7 +328,8 @@ void compute_crc_table(unsigned int* crc_table) {
 }
 
 
-unsigned int update_crc(unsigned int* crc_table, unsigned crc, uint8_t *buf, int len) {
+unsigned int update_crc(unsigned int* crc_table, unsigned crc,
+                           int8_t *buf, int len) {
 
   char b;
   unsigned c = crc ^ 0xffffffff;
@@ -346,7 +347,7 @@ unsigned int update_crc(unsigned int* crc_table, unsigned crc, uint8_t *buf, int
   return c ^ 0xffffffff;
 }
 
-unsigned crc32(unsigned char *buf, int len) {
+unsigned crc32(int8_t *buf, int len) {
   static unsigned int crc_table[256];
   
   compute_crc_table(crc_table);
@@ -356,7 +357,7 @@ unsigned crc32(unsigned char *buf, int len) {
 
 // TODO 
 
-int compare_checksum(char* data, struct waveform_data_header* header) {
+int compare_checksum(int8_t* data, struct waveform_data_header* header) {
   unsigned int crc;
   unsigned int crc_table[256];
   compute_crc_table(crc_table);
@@ -477,7 +478,7 @@ uint32_t get_waveform_length(uint32_t* wav_addrs, uint32_t wav_addr) {
   return 0;
 }
 
-uint16_t parse_waveform(char* data, uint32_t* wav_addrs, uint32_t wav_addr, FILE* outfile) {
+uint32_t parse_waveform(int8_t* data, uint32_t* wav_addrs, uint32_t wav_addr, FILE* outfile) {
   uint32_t i, j;
   struct packed_state* s;
   struct unpacked_state u;
@@ -485,8 +486,8 @@ uint16_t parse_waveform(char* data, uint32_t* wav_addrs, uint32_t wav_addr, FILE
   int fc_active;
   int zero_pad;
   size_t written;
-  uint16_t state_count = 0;
-  char* waveform = data + wav_addr;
+  uint32_t state_count = 0;
+  int8_t* waveform = data + wav_addr;
 
   // TODO
   // We are cutting off the last two bytes
@@ -553,7 +554,7 @@ int parse_temp_ranges(struct waveform_data_header* header, int8_t* data, int8_t*
   struct pointer* tr;
   uint8_t checksum;
   uint8_t i;
-  uint16_t state_count;
+  uint32_t state_count;
   size_t written;
   long ftable;
   long fprev;
@@ -744,7 +745,7 @@ int parse_modes(struct waveform_data_header* header, int8_t* data, int8_t* mode_
   return 0;
 }
 
-int check_xwia(char* xwia, int do_print) {
+int check_xwia(int8_t* xwia, int do_print) {
   uint8_t xwia_len;
   uint8_t i;
   uint8_t checksum;
@@ -997,7 +998,7 @@ int main(int argc, char **argv) {
     to_alloc = sizeof(struct waveform_data_header);
   }
 
-  data = malloc(to_alloc);
+  data = (int8_t*) malloc(to_alloc);
   if(!data) {
     fprintf(stderr, "Failed to allocate %d bytes of memory: %s\n", (int) st.st_size, strerror(errno));
     goto fail;


### PR DESCRIPTION
(chars are elements of C-strings, but here we use just bytes, signed and unsigned ones)