### PR TITLE
Fixed the location of mode table.

### DIFF
--- a/main.c
+++ b/main.c
@@ -1101,7 +1101,7 @@ int main(int argc, char **argv) {
 
   // first byte of xwia contains the length
   // last byte after xwia is a checksum
-  modes = data + header->xwia + 1 + xwia_len + 1;
+  modes = data + header->wmta;
 
   if(parse_modes(header, data, modes, header->mc + 1, header->trc + 1, wav_addrs, 1, NULL, 0) < 0) {
     fprintf(stderr, "Parse error during first pass\n");


### PR DESCRIPTION
It feeled weird we have to compute it from `xwia` location, which may be not present at all (but we used it anyway even if it is not, it is an obvious bug). Tracing has shown that the offset computed using the formula matches the offset in `wmta` field, so it is likely that that field should be used instead.